### PR TITLE
update playbook to work with latest patch on kepler-model-server

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,3 +1,3 @@
-kepler_model_server_image: quay.io/sustainable_computing_io/kepler_model_server:v0.7
+kepler_model_server_image: quay.io/sustainable_computing_io/kepler_model_server:latest
 ami_id: ami-0e4d0bb9670ea8db0
 region: us-east-2

--- a/roles/create_instance/tasks/main.yml
+++ b/roles/create_instance/tasks/main.yml
@@ -53,7 +53,7 @@
 
 - name: Set fact of new request id 
   set_fact:
-    request_id: "{{ set_request_id }}"
+    request_id: "{{ create_result.spot_request.spot_instance_request_id }}"
   when: set_request_id is undefined
 
 - name: Get info about the spot instance request created

--- a/roles/instance_collect_role/default/main.yml
+++ b/roles/instance_collect_role/default/main.yml
@@ -1,2 +1,2 @@
 ---
-kepler_model_server_image: quay.io/sustainable_computing_io/kepler_model_server:v0.7
+kepler_model_server_image: quay.io/sustainable_computing_io/kepler_model_server:latest

--- a/roles/instance_collect_role/files/install_package.sh
+++ b/roles/instance_collect_role/files/install_package.sh
@@ -19,3 +19,11 @@ modprobe intel_rapl_common
 
 # Install Git
 apt-get install git -y
+
+# Install Kind
+# For AMD64 / x86_64
+[ $(uname -m) = x86_64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.23.0/kind-linux-amd64
+# For ARM64
+[ $(uname -m) = aarch64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.23.0/kind-linux-arm64
+chmod +x ./kind
+sudo mv ./kind /usr/local/bin/kind

--- a/roles/instance_collect_role/tasks/main.yml
+++ b/roles/instance_collect_role/tasks/main.yml
@@ -28,13 +28,14 @@
   shell:
     chdir: kepler-model-server/model_training
     cmd: |
-      ./script.sh install_kepler
       ./script.sh deploy_kepler
       ./script.sh deploy_prom_dependency
   args:
     executable: /bin/bash
 
 - name: Install Tekton
+  environment:
+    KUBECONFIG: /tmp/kubeconfig
   shell:
     chdir: kepler-model-server
     cmd: |
@@ -55,6 +56,8 @@
     dest: kepler-model-server/model_training/tekton/aws-cos-secret.yaml
 
 - name: Deploy resources
+  environment:
+    KUBECONFIG: /tmp/kubeconfig
   shell:
     chdir: kepler-model-server/model_training/tekton
     cmd: |
@@ -84,6 +87,8 @@
     dest: kepler-model-server/model_training/tekton/self-hosted-aws-collect.yaml
 
 - name: Run Tekton Pipeline with S3Push
+  environment:
+    KUBECONFIG: /tmp/kubeconfig
   shell:
     chdir: kepler-model-server
     cmd: |
@@ -97,6 +102,8 @@
 - debug: var=run_tekton.stdout_lines
 
 - name: Log S3Push
+  environment:
+    KUBECONFIG: /tmp/kubeconfig
   shell:
     chdir: kepler-model-server
     cmd: |


### PR DESCRIPTION
The current playbook is outdate and not working with the latest changes on the kepler-model-server.
The main changes are
1. use latest image tag instead of 0.7
2. need kind installation in install_package
3. need to set KUBECONFIG

With these changes, the playbook can come back to functional.

```
       "pod/self-hosted-aws-collect-collect-metric-pod",
        "            260",
        "==== bpf ====",
        "1 pods: \tValid",
        "",
        "Valid data points:",
        "             >0",
        "scenarioID     ",
        "            130",
        "intel_rapl data: \t[540]",
        "acpi data: \t[270]",
        "pod/self-hosted-aws-collect-presteps-pod",
        "Empty",
        "==== bpf ====",
        "1 pods: \tNo data for ['']",
        "1 pods: \tZero data for ['']",
        "0 pods: \tValid",
        "",
        "Valid data points:",
        "Empty",
        "intel_rapl data: \t[136]",
        "acpi data: \t[68]",
        "FREQ_COUNT=1",
        "INSTANCE_COUNT=13",
        "TIME_PER_LOOP=25",
        "Estimation Time (s): 2600",
        "No frequency info",
        "CPU_FREQUENCY=none",
        "STRESS_INSTANCE_NUM=1",
        "ARGUMENTS=cpu;none;none",
        "Load=cpu",
        "ExtraKey=none",
        "pod/self-hosted-aws-collect-run-stressng-pod",
        "stress-ng: info:  [4548] successful run completed in 20.08 secs",
        "stress-ng: metrc: [4557] stressor       bogo ops real time  usr time  sys time   bogo ops/s     bogo ops/s",
        "stress-ng: metrc: [4557]                           (secs)    (secs)    (secs)   (real time) (usr+sys time)",
        "stress-ng: metrc: [4557] cpu                7430     20.06      9.67      0.21       370.33         752.66",
        "stress-ng: info:  [4557] passed: 1: cpu (1)",
        "stress-ng: info:  [4557] failed: 0",
        "stress-ng: info:  [4557] skipped: 0",
        "stress-ng: info:  [4557] metrics untrustworthy: 0",
        "stress-ng: info:  [4557] successful run completed in 20.08 secs",
        "finished",
        "NAME                                         READY   STATUS      RESTARTS   AGE",
        "self-hosted-aws-collect-aws-s3-push-pod      0/1     Completed   0          57s",
        "self-hosted-aws-collect-collect-metric-pod   0/1     Completed   0          69s",
        "self-hosted-aws-collect-presteps-pod         0/3     Completed   0          10m",
        "self-hosted-aws-collect-run-stressng-pod     0/2     Completed   0          7m52s"
    ]
}
```

This PR fixes https://github.com/sustainable-computing-io/kepler-model-training-playbook/issues/3

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>